### PR TITLE
Why hide project forms on xs devices?

### DIFF
--- a/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
+++ b/OurUmbraco.Site/Views/MacroPartials/Projects/ProjectDetails.cshtml
@@ -209,7 +209,7 @@
 
 
 
-                    <div class="package-forum-activity hidden-xs">
+                    <div class="package-forum-activity">
                         @{
                             var forums = CurrentPage.Children.Where("Visible");
                         }


### PR DESCRIPTION
removed the hidden-xs class on line 212 re: issuetracker issue http://issues.umbraco.org/issue/OUR-129
